### PR TITLE
fix(filter-logic): show items matching across filter groups

### DIFF
--- a/src/utils/filters.ts
+++ b/src/utils/filters.ts
@@ -5,25 +5,23 @@ export const getFilteredProducts = (
   products: BaseProduct[],
   filters: ProductFilter[],
 ) => {
-  const currentCheckedFilterOptions = filters
+  // Get an array of filter options where at least one option in the group is checked
+  const activeFilterGroups = filters
     .map(filter => filter.options.filter(option => option.checked))
-    .flat();
+    .filter(group => group.length > 0); // Keep only groups with checked options
 
-  if (currentCheckedFilterOptions.length === 0) {
-    return products;
+  if (activeFilterGroups.length === 0) {
+    return products; // If no filters are applied, return all products
   }
 
-  const filteredProducts = products.reduce<BaseProduct[]>((acc, product) => {
-    const allMatch = currentCheckedFilterOptions.some(option =>
-      product.subcategories.some(sub => sub.value === option.label),
+  const filteredProducts = products.filter(product => {
+    // Ensure the product satisfies at least one option from each filter group
+    return activeFilterGroups.every(group =>
+      group.some(option =>
+        product.subcategories.some(sub => sub.value === option.label),
+      )
     );
-
-    if (allMatch) {
-      acc.push(product);
-    }
-
-    return acc;
-  }, []);
+  });
 
   return filteredProducts;
 };


### PR DESCRIPTION
before: it shows all products which match one of list of checked options
now: it shows only products which match checked options from different
groups
